### PR TITLE
feat: add runs for 18.x

### DIFF
--- a/.github/workflows/18x-main.yml
+++ b/.github/workflows/18x-main.yml
@@ -1,0 +1,17 @@
+name: Check main for vulns daily
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 10 0 * * *
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-vulns:
+    uses: ./.github/workflows/check-vulns.yml
+    with:
+      nodejsStream: v18.x
+    secrets: inherit


### PR DESCRIPTION
Required scripts are now backported. Add runs for 18.x.

Signed-off-by: Michael Dawson <mdawson@devrus.com>