### PR TITLE
Create one issue per vulnerability, and prevent duplicates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,14 @@
 ---
-title: Vulnerability check reported failure on {{ env.NODEJS_STREAM }} - {{ date | date('YYYY-MM-DD') }}
+title: New vulnerability {{ env.VULN_ID }} found on {{ env.NODEJS_STREAM }}
 asignees:
 labels:
 ---
 Failed run: {{ env.ACTION_URL }}
+Vulnerability ID: {{ env.VULN_ID }}
 
-Output:
+Full output:
 --------------------
 ```
 {{ env.ERROR_MSG }}
 ```
+

--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   check-vulns:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set_matrix.outputs.matrix }}
+      full_output: ${{ steps.collect_error.outputs.result }}
     steps:
       - name: Setup Python 3.9
         uses: actions/setup-python@v3
@@ -44,6 +47,17 @@ jobs:
             set -o pipefail
             python main.py --gh-token ${{ secrets.GITHUB_TOKEN }} --nvd-key=${{ secrets.NVD_API_KEY }} 2>&1 | tee result.log
           )
+      - name: build matrix
+        id: set_matrix
+        if: ${{ failure() }}
+        working-directory: ./node/tools/dep_checker
+        run: |
+          matrix=$((echo '{ "vulnerability" : ['
+          cat result.log | sed -n 's/.*\(CVE-.*\|GHSA-.*\).*/"\1",/p' | sed '$s/,//'
+          echo "]}"
+          ) | jq -c .)
+          echo "::set-output name=matrix::$matrix"
+
       - name: collect error
         id: collect_error
         if: ${{ failure() }}
@@ -55,13 +69,21 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           echo "::set-output name=result::$content"
+  create-issues:
+    needs: check-vulns
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.check-vulns.outputs.matrix) }}
+    steps:
       - uses: actions/checkout@v3
-        if: ${{ failure() }}
-      - uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() }}
+      - uses: dblock/create-a-github-issue@v3
+        with:
+          update_existing: false
+          search_existing: all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ERROR_MSG: ${{ steps.collect_error.outputs.result }}
+          ERROR_MSG: ${{ needs.check-vulns.outputs.full_output }}
+          VULN_ID: ${{ matrix.vulnerability }}
           NODEJS_STREAM: ${{ inputs.nodejsStream }}
           ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-


### PR DESCRIPTION
## Description
This changes the GH Actions workflow so that a new issue is created for each new vulnerability detected. If an issue already exists, it won't create a new one.
This prevents the current issue, where a new issue will be created each day with the same vulnerabilities, until the script stops reporting them.

## Screenshot
<img src="https://user-images.githubusercontent.com/5762120/182595597-942c8c3e-5239-43ac-a078-15c329544a3a.png" width="600">


## How it works:
- The output of the script is parsed to extract all the vulnerabilities IDs
- Those IDs are inserted into a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), so that one job will be run for each
- The new job `create-issues` will be run for each vulnerability and create an issue with the title `New vulnerability CVE-XXXX-YYYYY found on main`
- If an issue with the same title already exists (open or closed), it won't create a new issue