### PR TITLE
fix: correct name for v18.x workflow

### DIFF
--- a/.github/workflows/18x-main.yml
+++ b/.github/workflows/18x-main.yml
@@ -1,4 +1,4 @@
-name: Check main for vulns daily
+name: Check v18.x for vulns daily
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Update the `name` of the v18.x workflow to reflect the branch checked.