### PR TITLE
Fix label error and deprecation warnings

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 title: New vulnerability {{ env.VULN_ID }} found on {{ env.NODEJS_STREAM }}
 asignees:
-labels: {{ env.NODEJS_STREAM }}
+labels: "{{ env.NODEJS_STREAM }}"
 ---
 Failed run: {{ env.ACTION_URL }}
 Vulnerability ID: {{ env.VULN_ID }}

--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -28,7 +28,7 @@ jobs:
       full_output: ${{ steps.collect_error.outputs.result }}
     steps:
       - name: Setup Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - name: Checkout current repository

--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -58,7 +58,7 @@ jobs:
           cat result.log | sed -n 's/.*\(CVE-.*\|GHSA-.*\).*/"\1",/p' | sed '$s/,//'
           echo "]}"
           ) | jq -c .)
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
       - name: collect error
         id: collect_error
@@ -70,7 +70,7 @@ jobs:
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
-          echo "::set-output name=result::$content"
+          echo "result=$content" >> $GITHUB_OUTPUT
   create-issues:
     needs: check-vulns
     if: ${{ always() }}


### PR DESCRIPTION
This PR fixes the [recent errors](https://github.com/nodejs/nodejs-dependency-vuln-assessments/actions/runs/3317298398) (`list.split is not a function`) caused by the lack of quotes in the label in `ISSUE_TEMPLATE.md`

It also fixes the deprecation errors related to the use of `set-output` by replacing it with Environment Files (i.e `$GITHUB_OUTPUT`) and by upgrading the `setup-python`.

The remaining deprecation warnings are caused by one of the actions we use ([dblock/create-a-github-issue](https://github.com/dblock/create-a-github-issue)). An issue has been opened in the repo asking for the changes that will remove the warnings: https://github.com/dblock/create-a-github-issue/issues/10.

This fixes https://github.com/nodejs/nodejs-dependency-vuln-assessments/issues/64