### PR TITLE
Add JSON output to script and change issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,10 @@
 ---
-title: New vulnerability {{ env.VULN_ID }} found on {{ env.NODEJS_STREAM }}
+title: "{{ env.VULN_ID }} ({{ env.VULN_DEP_NAME }}) found on {{ env.NODEJS_STREAM }}"
 asignees:
 labels: "{{ env.NODEJS_STREAM }}"
 ---
-Failed run: {{ env.ACTION_URL }}
+
+A new vulnerability for {{ env.VULN_DEP_NAME }} {{ env.VULN_DEP_VERSION }} was found:
 Vulnerability ID: {{ env.VULN_ID }}
-
-Full output:
---------------------
-```
-{{ env.ERROR_MSG }}
-```
-
+Vulnerability URL: {{ env.VULN_URL }}
+Failed run: {{ env.ACTION_URL }}

--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set_matrix.outputs.matrix }}
-      full_output: ${{ steps.collect_error.outputs.result }}
     steps:
       - name: Setup Python 3.9
         uses: actions/setup-python@v4
@@ -47,30 +46,16 @@ jobs:
         run: |
           (
             set -o pipefail
-            python main.py --gh-token ${{ secrets.GITHUB_TOKEN }} --nvd-key=${{ secrets.NVD_API_KEY }} ../node ${{ inputs.nodejsStream }} 2>&1 | tee result.log
+            python main.py --json-output --gh-token ${{ secrets.GITHUB_TOKEN }} --nvd-key=${{ secrets.NVD_API_KEY }} ../node ${{ inputs.nodejsStream }} 2>&1 | tee result.log
           )
       - name: build matrix
         id: set_matrix
         if: ${{ failure() }}
         working-directory: ./dep_checker
         run: |
-          matrix=$((echo '{ "vulnerability" : ['
-          cat result.log | sed -n 's/.*\(CVE-.*\|GHSA-.*\).*/"\1",/p' | sed '$s/,//'
-          echo "]}"
-          ) | jq -c .)
+          matrix=$(cat result.log | jq -c .)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-      - name: collect error
-        id: collect_error
-        if: ${{ failure() }}
-        working-directory: ./dep_checker
-        run: |
-          content=$(cat result.log)
-          # New lines must be escaped since outputs cannot be multi-line
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          echo "result=$content" >> $GITHUB_OUTPUT
   create-issues:
     needs: check-vulns
     if: ${{ always() }}
@@ -85,7 +70,9 @@ jobs:
           search_existing: all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ERROR_MSG: ${{ needs.check-vulns.outputs.full_output }}
-          VULN_ID: ${{ matrix.vulnerability }}
+          VULN_ID: ${{ matrix.vulnerabilities.id }}
+          VULN_URL: ${{ matrix.vulnerabilities.url }}
+          VULN_DEP_NAME: ${{ matrix.vulnerabilities.dependency }}
+          VULN_DEP_VERSION: ${{ matrix.vulnerabilities.version }}
           NODEJS_STREAM: ${{ inputs.nodejsStream }}
           ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Description

This change adds a new `--json-output` flag to the script, which outputs the vulnerabilities found as a JSON string. It also adapts the GH Action to use it, instead of manually parsing the original output.

It also changes the template for the created issues, which now contains the dependency name in its title, and a description that only mentions the relevant vulnerability (instead of the full output of the script).

## Screenshot
<img width="962" alt="image" src="https://user-images.githubusercontent.com/5762120/198013884-3284ff42-cae4-4166-82ce-579482bd0565.png">

## Details
- This fixes https://github.com/nodejs/nodejs-dependency-vuln-assessments/issues/66
