### PR TITLE
Add support for v19.x branch to the script

### DIFF
--- a/dep_checker/dependencies.py
+++ b/dep_checker/dependencies.py
@@ -56,6 +56,7 @@ common_dependencies: list[str] = [
 
 dependencies_per_branch: dict[str, list[str]] = {
     "main": common_dependencies + ["nghttp3", "ngtcp2", "undici"],
+    "v19.x": common_dependencies + ["nghttp3", "ngtcp2", "undici"],
     "v18.x": common_dependencies + ["nghttp3", "ngtcp2", "undici"],
     "v16.x": common_dependencies + ["undici"],
     "v14.x": common_dependencies,


### PR DESCRIPTION
A GH action for v19.x was added in https://github.com/nodejs/nodejs-dependency-vuln-assessments/pull/68. This PR adds support for v19.x to the script itself.

Fixes the following error:
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/5762120/198032220-f8e73500-250d-421e-803b-2545bee722bc.png">


And also fixes https://github.com/nodejs/nodejs-dependency-vuln-assessments/issues/65

cc @mhdawson @RafaelGSS 