### PR TITLE
Remove parallel runs to avoid hitting GH rate limit

### DIFF
--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.check-vulns.outputs.matrix) }}
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v3
       - uses: dblock/create-a-github-issue@v3

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -24,6 +24,7 @@ jobs:
     secrets: inherit
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         nodejsStream: ${{ fromJSON(needs.get-supported-versions.outputs.matrix) }}
     uses: ./.github/workflows/check-vulns.yml


### PR DESCRIPTION
Removes parallelism from the `check-vulns` action (so that each branch executes sequentially), and from the `create-issues` step (so that each issue is created sequentially). 
Should fix (or at least alleviate) https://github.com/nodejs/nodejs-dependency-vuln-assessments/issues/80