### PR TITLE
Use new NVD API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,18 @@
 This repo is used to
 
 1. Run automated checks for vulnerabilities in Node.js dependencies that have
-   already been made public
-1. Track and communicate information about vulnerabilities in depdencies that
-   are public and have not yet been addressed. This maybe be to documented
-   that they don't affect Node.js or what action is being taken to address
-   then.
+   already been made public.
+2. Track and communicate information about dependency vulnerabilities that
+   are public and have not yet been addressed.
 
 
 Automated checks are currently run through a GitHub action using
-[dep_checker](https://github.com/nodejs/node/tree/main/tools/dep_checker).
+[dep_checker](https://github.com/nodejs/nodejs-dependency-vuln-assessments/tree/main/dep_checker).
 
-**DO NOT REPORT OR DISCUSS VULNERABLITIES THAT ARE NOT ALREADY
+**DO NOT REPORT OR DISCUSS VULNERABILITIES THAT ARE NOT ALREADY
 PUBLIC IN THIS REPO**. Please report new vulnerabilities either to
 the projects for a specific dependency or report to the Node.js project
-as outlined in the Node.js project's
+as outlined in the Node.js
 [SECURITY.md](https://github.com/nodejs/node/blob/main/SECURITY.md) file.
 
 

--- a/dep_checker/main.py
+++ b/dep_checker/main.py
@@ -12,7 +12,6 @@ which case the vulnerability is ignored.
 """
 
 from argparse import ArgumentParser
-from collections import defaultdict
 from dependencies import (
     ignore_list,
     dependencies_info,
@@ -146,7 +145,7 @@ def query_nvd(
         query_results = [
             cve
             for cve in searchCVE(
-                cpeMatchString=dep.get_cpe(repo_path), keyword=dep.keyword, key=api_key
+                virtualMatchString=dep.get_cpe(repo_path), keywordSearch=dep.keyword, key=api_key
             )
             if cve.id not in ignore_list
         ]
@@ -216,7 +215,7 @@ def main() -> int:
         if name in dependencies_per_branch[repo_branch]
     }
     ghad_vulnerabilities: list[Vulnerability] = (
-        {} if gh_token is None else query_ghad(dependencies, gh_token, repo_path)
+        list() if gh_token is None else query_ghad(dependencies, gh_token, repo_path)
     )
     nvd_vulnerabilities: list[Vulnerability] = query_nvd(
         dependencies, nvd_key, repo_path

--- a/dep_checker/main.py
+++ b/dep_checker/main.py
@@ -145,7 +145,7 @@ def query_nvd(
         query_results = [
             cve
             for cve in searchCVE(
-                virtualMatchString=dep.get_cpe(repo_path), keywordSearch=dep.keyword, key=api_key
+                virtualMatchString=dep.get_cpe(repo_path), keywordSearch=dep.keyword, key=api_key, delay=6 if api_key else False
             )
             if cve.id not in ignore_list
         ]

--- a/dep_checker/main.py
+++ b/dep_checker/main.py
@@ -39,7 +39,12 @@ class Vulnerability:
 class VulnerabilityEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Vulnerability):
-            return {"id": obj.id, "url": obj.url, "dependency": obj.dependency, "version": obj.version}
+            return {
+                "id": obj.id,
+                "url": obj.url,
+                "dependency": obj.dependency,
+                "version": obj.version,
+            }
         # Let the base class default method raise the TypeError
         return json.JSONEncoder.default(self, obj)
 
@@ -117,7 +122,10 @@ def query_ghad(
             found_vulnerabilities.extend(
                 [
                     Vulnerability(
-                        id=vuln["advisory"]["ghsaId"], url=vuln["advisory"]["permalink"], dependency=name, version=dep_version
+                        id=vuln["advisory"]["ghsaId"],
+                        url=vuln["advisory"]["permalink"],
+                        dependency=name,
+                        version=dep_version,
                     )
                     for vuln in matching_vulns
                 ]
@@ -145,14 +153,22 @@ def query_nvd(
         query_results = [
             cve
             for cve in searchCVE(
-                virtualMatchString=dep.get_cpe(repo_path), keywordSearch=dep.keyword, key=api_key, delay=6 if api_key else False
+                virtualMatchString=dep.get_cpe(repo_path),
+                keywordSearch=dep.keyword,
+                key=api_key,
+                delay=6 if api_key else False,
             )
             if cve.id not in ignore_list
         ]
         if query_results:
             version = dep.version_parser(repo_path)
             found_vulnerabilities.extend(
-                [Vulnerability(id=cve.id, url=cve.url, dependency=name, version=version) for cve in query_results]
+                [
+                    Vulnerability(
+                        id=cve.id, url=cve.url, dependency=name, version=version
+                    )
+                    for cve in query_results
+                ]
             )
 
     return found_vulnerabilities
@@ -184,7 +200,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--json-output",
-        action='store_true',
+        action="store_true",
         help="the NVD API key for querying the National Vulnerability Database",
     )
     repo_path: Path = parser.parse_args().node_repo_path
@@ -221,7 +237,9 @@ def main() -> int:
         dependencies, nvd_key, repo_path
     )
 
-    all_vulnerabilities = {"vulnerabilities": ghad_vulnerabilities + nvd_vulnerabilities}
+    all_vulnerabilities = {
+        "vulnerabilities": ghad_vulnerabilities + nvd_vulnerabilities
+    }
     no_vulnerabilities_found = not ghad_vulnerabilities and not nvd_vulnerabilities
     if json_output:
         print(json.dumps(all_vulnerabilities, cls=VulnerabilityEncoder))

--- a/dep_checker/requirements.txt
+++ b/dep_checker/requirements.txt
@@ -1,3 +1,3 @@
 gql[aiohttp]
-nvdlib==0.6.0
+nvdlib==0.7.0
 packaging


### PR DESCRIPTION
This PR updates `nvdlib` to `0.7.0`, which starts using NVD's new v2 API (the old API will be deprecated in 2023). In addition, it starts using a delay between requests (as recommended [here](https://github.com/vehemont/nvdlib/blob/v0.7.0/nvdlib/cve.py#L94)) and fixes some minor formatting and documentation errors.
