### PR TITLE
fix: update version of nvdlib

### DIFF
--- a/dep_checker/requirements.txt
+++ b/dep_checker/requirements.txt
@@ -1,3 +1,3 @@
 gql[aiohttp]
-nvdlib==0.7.1
+nvdlib==0.7.4
 packaging


### PR DESCRIPTION
Recent runs have failed with a timeout. Update to most recent version of nvdlib

@RafaelGSS could I get a quick review of this?