### PR TITLE
Only check for open issues, when looking for existing issue

### DIFF
--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: dblock/create-a-github-issue@v3
         with:
           update_existing: false
-          search_existing: all
+          search_existing: open
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VULN_ID: ${{ matrix.vulnerabilities.id }}


### PR DESCRIPTION
I think we should only check open issues, otherwise if we incorrectly close one it will not be recreated.