### PR TITLE
Change when we run checks

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,7 +3,7 @@ name: Check for vulnerabilities daily
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 5 * * *
 
 permissions:
   contents: read


### PR DESCRIPTION
Lets avoid midnight as a common time to see if that has any effect on the failures, some of which seem to be related to rate limiting in creating CVEs, other in availability of the CVE database.