### PR TITLE
chore: update version of nvdlib

### DIFF
--- a/dep_checker/requirements.txt
+++ b/dep_checker/requirements.txt
@@ -1,3 +1,3 @@
 gql[aiohttp]
-nvdlib==0.7.4
+nvdlib==0.7.7
 packaging


### PR DESCRIPTION
There have been failures for the last few days. It may a problem with the database, but want to update to the latest version of nvdlib before I open an issue there.