### PR TITLE
workflows: ignore warning on result.log

### DIFF
--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -53,7 +53,7 @@ jobs:
         if: ${{ failure() }}
         working-directory: ./dep_checker
         run: |
-          matrix=$(cat result.log | jq -c .)
+          matrix=$(grep -o '{.*}' result.log | jq -c .)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   create-issues:


### PR DESCRIPTION
Fixes: https://github.com/nodejs/nodejs-dependency-vuln-assessments/issues/202