### PR TITLE
fix: CJS Module Lexer detection for Node.js 20

### DIFF
--- a/dep_checker/dependencies.py
+++ b/dep_checker/dependencies.py
@@ -137,11 +137,7 @@ dependencies_info: dict[str, Dependency] = {
         npm_name="corepack",
     ),
     "CJS Module Lexer": Dependency(
-        version_parser=lambda repo_path: (
-            vp.get_cjs_lexer_version(repo_path) 
-            if int(vp.get_node_version(repo_path).split(".")[0]) > 20 
-            else vp.get_cjs_lexer_version_old(repo_path)
-        ),
+        version_parser=vp.get_cjs_lexer_version,
         cpe=None,
         keyword="cjs-module-lexer",
         npm_name="cjs-module-lexer",

--- a/dep_checker/versions_parser.py
+++ b/dep_checker/versions_parser.py
@@ -48,8 +48,6 @@ def get_c_ares_version(repo_path: Path) -> str:
             raise RuntimeError("Error extracting version number for c-ares")
         return matches.groupdict()["version"]
 
-def get_cjs_lexer_version_old(repo_path: Path) -> str:
-    return get_package_json_version(repo_path / "deps/cjs-module-lexer/package.json")
 
 def get_cjs_lexer_version(repo_path: Path) -> str:
     return get_package_json_version(repo_path / "deps/cjs-module-lexer/src/package.json")


### PR DESCRIPTION
Node.js 20.19.5 updated CJS Module Lexer so it is now in the same layout on the filesystem as in later versions.

---

Fixes:
e.g. https://github.com/nodejs/nodejs-dependency-vuln-assessments/actions/runs/17875656424/job/50836684901#step:6:15
```
Traceback (most recent call last):
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/main.py", line 261, in <module>
    exit(main())
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/main.py", line 234, in main
    list() if gh_token is None else query_ghad(dependencies, gh_token, repo_path)
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/main.py", line 113, in query_ghad
    dep_version = dep.version_parser(repo_path)
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/dependencies.py", line 143, in <lambda>
    else vp.get_cjs_lexer_version_old(repo_path)
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/versions_parser.py", line 52, in get_cjs_lexer_version_old
    return get_package_json_version(repo_path / "deps/cjs-module-lexer/package.json")
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/versions_parser.py", line 8, in get_package_json_version
    with open(path, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: '../node/deps/cjs-module-lexer/package.json'
Error: Process completed with exit code 1.
```