### PR TITLE
workflows: handle when GITHUB_OUTPUT is empty

### DIFF
--- a/.github/workflows/check-vulns.yml
+++ b/.github/workflows/check-vulns.yml
@@ -58,7 +58,7 @@ jobs:
 
   create-issues:
     needs: check-vulns
-    if: ${{ always() }}
+    if: ${{ always() && needs.check-vulns.outputs.matrix != '' }}
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.check-vulns.outputs.matrix) }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -21,6 +21,7 @@ jobs:
   check-vulns:
     name: Check vulnerabilities on ${{ matrix.nodejsStream }}
     needs: get-supported-versions
+    if: ${{ needs.get-supported-versions.outputs.matrix != '' }}
     secrets: inherit
     strategy:
       fail-fast: false


### PR DESCRIPTION
This should fix https://github.com/nodejs/nodejs-dependency-vuln-assessments/actions/runs/18302628105