### PR TITLE
fix: CJS Module Lexer replaced by merve

### DIFF
--- a/dep_checker/dependencies.py
+++ b/dep_checker/dependencies.py
@@ -43,7 +43,6 @@ common_dependencies: list[str] = [
     "acorn",
     "brotli",
     "c-ares",
-    "CJS Module Lexer",
     "corepack",
     "HdrHistogram",
     "ICU",
@@ -58,15 +57,17 @@ common_dependencies: list[str] = [
 ]
 
 # Define branch-specific dependencies
-main_specific = ["simdutf"]
-v22_specific = ["simdutf"]
-v20_specific = ["simdutf"]
+main_specific = ["merve"]
+v25_specific = ["merve"]
+v24_specific = ["merve"]
+v22_specific = ["CJS Module Lexer", "simdutf"]
+v20_specific = ["CJS Module Lexer", "simdutf"]
 
 # Combine common dependencies with branch-specific ones
 dependencies_per_branch: dict[str, list[str]] = {
-    "main": common_dependencies,  # No simdutf in  main
-    "v24.x": common_dependencies,  # No simdutf in v24.x
-    "v23.x": common_dependencies,  # No simdutf in v23.x
+    "main": common_dependencies + main_specific,
+    "v25.x": common_dependencies + v25_specific,
+    "v24.x": common_dependencies + v24_specific,
     "v22.x": common_dependencies + v22_specific,
     "v20.x": common_dependencies + v20_specific,
 }
@@ -117,6 +118,11 @@ dependencies_info: dict[str, Dependency] = {
     "nghttp2": Dependency(
         version_parser=vp.get_nghttp2_version,
         cpe=CPE(vendor="nghttp2", product="nghttp2"),
+    ),
+    "merve": Dependency(
+        version_parser=vp.get_merve_version,
+        cpe=None,
+        keyword="merve",
     ),
     "llhttp": Dependency(
         version_parser=vp.get_llhttp_version,

--- a/dep_checker/versions_parser.py
+++ b/dep_checker/versions_parser.py
@@ -80,6 +80,14 @@ def get_llhttp_version(repo_path: Path) -> str:
         return f"{versions['major']}.{versions['minor']}.{versions['patch']}"
 
 
+def get_merve_version(repo_path: Path) -> str:
+    with open(repo_path / "deps/merve/merve.h", "r") as f:
+        matches = re.search('#define MERVE_VERSION "(?P<version>.*)"', f.read())
+        if matches is None:
+            raise RuntimeError("Error extracting version number for merve")
+        return matches.groupdict()["version"]
+
+
 def get_nghttp2_version(repo_path: Path) -> str:
     with open(repo_path / "deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h", "r") as f:
         matches = re.search('#define NGHTTP2_VERSION "(?P<version>.*)"', f.read())


### PR DESCRIPTION
Update the checker to account for CJS Module Lexer gradually being replaced with merve.

---

Currently broken for the release lines where the replacement has already happened, e.g. 
https://github.com/nodejs/nodejs-dependency-vuln-assessments/actions/runs/22383732503/job/64790456705#step:6:15
```
Traceback (most recent call last):
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/main.py", line 261, in <module>
    exit(main())
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/main.py", line 234, in main
    list() if gh_token is None else query_ghad(dependencies, gh_token, repo_path)
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/main.py", line 113, in query_ghad
    dep_version = dep.version_parser(repo_path)
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/versions_parser.py", line 53, in get_cjs_lexer_version
    return get_package_json_version(repo_path / "deps/cjs-module-lexer/src/package.json")
  File "/home/runner/work/nodejs-dependency-vuln-assessments/nodejs-dependency-vuln-assessments/dep_checker/versions_parser.py", line 8, in get_package_json_version
    with open(path, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: '../node/deps/cjs-module-lexer/src/package.json'
Error: Process completed with exit code 1.
```