### PR TITLE
fix: c-ares, sqlite and zstd version parsing

### DIFF
--- a/dep_checker/dependencies.py
+++ b/dep_checker/dependencies.py
@@ -102,7 +102,7 @@ dependencies_info: dict[str, Dependency] = {
     ),
     "zstd": Dependency(
         version_parser=vp.get_zstd_version,
-        cpe=CPE(vendor="zstd", product="zstd"),
+        cpe=CPE(vendor="facebook", product="zstandard"),
     ),
     # TODO: Add V8
     # "V8": Dependency("cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*", "v8"),

--- a/dep_checker/versions_parser.py
+++ b/dep_checker/versions_parser.py
@@ -43,7 +43,7 @@ def get_brotli_version(repo_path: Path) -> str:
 
 def get_c_ares_version(repo_path: Path) -> str:
     with open(repo_path / "deps/cares/include/ares_version.h", "r") as f:
-        matches = re.search('#define ARES_VERSION_STR "(?P<version>.*)"', f.read())
+        matches = re.search(r'#define ARES_VERSION_STR\s+"(?P<version>.*)"', f.read())
         if matches is None:
             raise RuntimeError("Error extracting version number for c-ares")
         return matches.groupdict()["version"]

--- a/dep_checker/versions_parser.py
+++ b/dep_checker/versions_parser.py
@@ -286,7 +286,7 @@ def get_simdjson_version(repo_path: Path) -> str:
 
 def get_sqlite_version(repo_path: Path) -> str:
     with open(repo_path / "deps/sqlite/sqlite3.h", "r") as f:
-        matches = re.search('#define SQLITE_VERSION "(?P<version>.*)"', f.read())
+        matches = re.search(r'#define SQLITE_VERSION\s+"(?P<version>.*)"', f.read())
         if matches is None:
             raise RuntimeError("Error extracting version number for sqlite")
         return matches.groupdict()["version"]

--- a/dep_checker/versions_parser.py
+++ b/dep_checker/versions_parser.py
@@ -259,16 +259,16 @@ def get_zlib_version(repo_path: Path) -> str:
 def get_zstd_version(repo_path: Path) -> str:
     with open(repo_path / "deps/zstd/lib/zstd.h", "r") as f:
         matches = re.search(
-            "#define ZSTD_VERSION_MAJOR (?P<major>.*)\n"
-            "#define ZSTD_VERSION_MINOR (?P<minor>.*)\n"
-            "#define ZSTD_VERSION_PATCH (?P<patch>.*)",
+            r"#define ZSTD_VERSION_MAJOR\s+(?P<major>.*)\n"
+            r"#define ZSTD_VERSION_MINOR\s+(?P<minor>.*)\n"
+            r"#define ZSTD_VERSION_RELEASE\s+(?P<release>.*)",
             f.read(),
             re.MULTILINE,
         )
         if matches is None:
             raise RuntimeError("Error extracting version number for zstd")
         versions = matches.groupdict()
-        return f"{versions['major']}.{versions['minor']}.{versions['patch']}"
+        return f"{versions['major']}.{versions['minor']}.{versions['release']}"
 
 def get_simdutf_version(repo_path: Path) -> str:
     with open(repo_path / "deps/simdutf/simdutf.h", "r") as f:


### PR DESCRIPTION
- The version parser for sqlite was only expecting a single space between the `#define SQLITE_VERSION` and the version string but the actual header has multiple spaces.
- The header file for zstd defines `ZSTD_VERSION_RELEASE` instead of `ZSTD_VERSION_PATCH`. Allow for multiple spaces is the definition. The CPE vendor for zstd is `facebook` and the product is `zstandard`.
- Newer versions of c-ares have multiple spaces in the definition of `ARES_VERSION_STR` that break the existing parsing.

Fixes: https://github.com/nodejs/nodejs-dependency-vuln-assessments/issues/307